### PR TITLE
Add xG weight blending and fit_xg_weight optimization (issue #12)

### DIFF
--- a/R/api-interface.R
+++ b/R/api-interface.R
@@ -273,33 +273,63 @@ load_or_get_nst <- function(gid) {
   season <- paste0(season, season + 1)
   season <- as.numeric(season)
 
-  if (
-    system2(
-      "grep",
-      paste0('-l "', gid, '" ', "~/Documents/natstattrick.csv"),
-      stdout = FALSE
-    ) ==
-      0
-  ) {
-    nstall <- utils::read.csv("~/Documents/natstattrick.csv")
-    nstdf <- nstall |>
-      dplyr::filter(.data$game_id == gid)
-  } else {
-    nstdf <- naturalstattrick::nst_report_df(
-      season = season,
-      game_id = game_id
+  # Use a configurable path for cached Natural Stat Trick data. Allows users to
+  # provide a CSV with previously fetched nst reports. Default matches prior
+  # behavior (~/Documents/natstattrick.csv).
+  xg_path <- getOption("HockeyModel.xg.path", "~/Documents/natstattrick.csv")
+  xg_path <- path.expand(xg_path)
+
+  if (file.exists(xg_path)) {
+    nstall <- tryCatch(
+      utils::read.csv(xg_path, stringsAsFactors = FALSE),
+      error = function(e) NULL
     )
-    nstdf <- nstdf |>
-      dplyr::mutate("game_id" = gid)
-    utils::write.table(
-      nstdf,
-      file = "~/Documents/natstattrick.csv",
-      append = TRUE,
-      row.names = FALSE,
-      col.names = FALSE,
-      sep = ","
-    )
+    if (!is.null(nstall) && "game_id" %in% names(nstall)) {
+      nstdf <- nstall |>
+        dplyr::filter(.data$game_id == gid)
+      if (nrow(nstdf) > 0) {
+        return(nstdf)
+      }
+    }
   }
+
+  # Fallback: fetch from naturalstattrick package
+  nstdf <- naturalstattrick::nst_report_df(
+    season = season,
+    game_id = game_id
+  )
+  nstdf <- nstdf |>
+    dplyr::mutate("game_id" = gid)
+
+  # Attempt to cache result to the configured path.  If writing fails, warn
+  # but continue and return the fetched data.
+  tryCatch(
+    {
+      if (file.exists(xg_path)) {
+        utils::write.table(
+          nstdf,
+          file = xg_path,
+          append = TRUE,
+          row.names = FALSE,
+          col.names = FALSE,
+          sep = ","
+        )
+      } else {
+        utils::write.table(
+          nstdf,
+          file = xg_path,
+          append = FALSE,
+          row.names = FALSE,
+          col.names = TRUE,
+          sep = ","
+        )
+      }
+    },
+    error = function(e) {
+      message("Warning: could not write xG cache to ", xg_path, ": ", e$message)
+    }
+  )
+
   closeAllConnections()
 
   return(nstdf)
@@ -694,7 +724,7 @@ getAPISeries <- function(season = getCurrentSeason8()) {
       "HomeSeed" = as.integer(.data$HomeSeed),
       "AwaySeed" = as.integer(.data$AwaySeed)
     )
-  return(playoffSeries[complete.cases(playoffSeries),])
+  return(playoffSeries[complete.cases(playoffSeries), ])
 }
 
 

--- a/R/dixon-coles.R
+++ b/R/dixon-coles.R
@@ -65,6 +65,7 @@ todayDC <- function(
   expected_mean = NULL,
   season_percent = NULL,
   include_xG = FALSE,
+  use_xg = FALSE,
   draws = TRUE
 ) {
   stopifnot(is.Date(today))
@@ -94,7 +95,8 @@ todayDC <- function(
       params = params,
       expected_mean = expected_mean,
       season_percent = season_percent,
-      draws = draws
+      draws = draws,
+      use_xg = use_xg
     )
     if (draws) {
       preds$HomeWin[[i]] <- p[[1]]
@@ -109,7 +111,8 @@ todayDC <- function(
       xg <- dcxG(
         home = preds$HomeTeam[[i]],
         away = preds$AwayTeam[[i]],
-        params = params
+        params = params,
+        use_xg = use_xg
       )
       preds$Home_xG[[i]] <- xg$home
       preds$Away_xG[[i]] <- xg$away
@@ -134,13 +137,13 @@ todayDC <- function(
 #'
 #' @return home ice advantage team odds to win series
 #' @export
-playoffDC <- function(home, away, params = NULL, home_wins = 0, away_wins = 0) {
+playoffDC <- function(home, away, params = NULL, home_wins = 0, away_wins = 0, use_xg = FALSE) {
   params <- parse_dc_params(params)
   # Odds of home ice advantage team win at home
-  homeodds <- DCPredict(home = home, away = away, params = params)
+  homeodds <- DCPredict(home = home, away = away, params = params, use_xg = use_xg)
   homeodds <- normalizeOdds(c(homeodds[1], homeodds[3]))[1]
   # Odds of home ice advantage team win away
-  awayodds <- DCPredict(home = away, away = home, params = params)
+  awayodds <- DCPredict(home = away, away = home, params = params, use_xg = use_xg)
   awayodds <- normalizeOdds(c(awayodds[3], awayodds[1]))[1]
 
   homewin <- playoffSeriesOdds(homeodds, awayodds, home_wins, away_wins)
@@ -170,7 +173,8 @@ remainderSeasonDC <- function(
   schedule = HockeyModel::schedule,
   odds = FALSE,
   regress = TRUE,
-  mu_lambda = FALSE
+  mu_lambda = FALSE,
+  use_xg = FALSE
 ) {
   odds_table <- data.frame(
     HomeTeam = character(),
@@ -232,7 +236,8 @@ remainderSeasonDC <- function(
       schedule = schedule,
       season_percent = season_percent,
       expected_mean = expected_mean,
-      params = params
+      params = params,
+      use_xg = use_xg
     )
     preds$Date <- d
     odds_table <- rbind(odds_table, preds)
@@ -553,14 +558,19 @@ DCPredict <- function(
   scores = HockeyModel::scores,
   expected_mean = NULL,
   season_percent = NULL,
-  draws = TRUE
+  draws = TRUE,
+  use_xg = FALSE
 ) {
   params <- parse_dc_params(params = params)
   probability_matrix <- dcProbMatrix(
     home = home,
     away = away,
     params = params,
-    maxgoal = maxgoal
+    maxgoal = maxgoal,
+    scores = scores,
+    expected_mean = expected_mean,
+    season_percent = season_percent,
+    use_xg = use_xg
   )
 
   HomeWinProbability <- sum(probability_matrix[lower.tri(probability_matrix)])
@@ -595,7 +605,43 @@ DCPredict <- function(
 #' @param params The named list containing m, rho, beta, eta, and k. See [updateDC] for information on the params list
 #'
 #' @return a list of $home and $away Poisson Lambda values -
-dcLambda <- function(home, away, params = NULL) {
+get_team_xg_stats <- function(scores = HockeyModel::scores) {
+  if (is.null(scores)) return(NULL)
+  if (!all(c("HomexG", "AwayxG", "HomeTeam", "AwayTeam") %in% names(scores))) {
+    return(NULL)
+  }
+
+  df_home <- data.frame(
+    Team = scores$HomeTeam,
+    xg_for = as.numeric(scores$HomexG),
+    xg_against = as.numeric(scores$AwayxG),
+    stringsAsFactors = FALSE
+  )
+  df_away <- data.frame(
+    Team = scores$AwayTeam,
+    xg_for = as.numeric(scores$AwayxG),
+    xg_against = as.numeric(scores$HomexG),
+    stringsAsFactors = FALSE
+  )
+  long_df <- dplyr::bind_rows(df_home, df_away)
+  long_df <- long_df[stats::complete.cases(long_df), ]
+  if (nrow(long_df) == 0) return(NULL)
+
+  team_stats <- long_df |>
+    dplyr::group_by(.data$Team) |>
+    dplyr::summarize(
+      xg_for = mean(.data$xg_for, na.rm = TRUE),
+      xg_against = mean(.data$xg_against, na.rm = TRUE),
+      .groups = "drop"
+    )
+  team_xg_for <- setNames(team_stats$xg_for, team_stats$Team)
+  team_xg_against <- setNames(team_stats$xg_against, team_stats$Team)
+  league_avg <- mean(long_df$xg_for, na.rm = TRUE)
+  return(list(team_xg_for = team_xg_for, team_xg_against = team_xg_against, league_avg = league_avg))
+}
+
+
+dcLambda <- function(home, away, params = NULL, scores = HockeyModel::scores, use_xg = FALSE) {
   params <- parse_dc_params(params = params)
   xg <- list("home" = NA, "away" = NA)
 
@@ -634,15 +680,31 @@ dcLambda <- function(home, away, params = NULL) {
     )
   }
 
+  # Optionally adjust predicted goals using team-level average xG from historical data.
+  if (isTRUE(use_xg)) {
+    team_stats <- tryCatch(get_team_xg_stats(scores), error = function(e) NULL)
+    if (!is.null(team_stats)) {
+      home_xg_team <- team_stats$team_xg_for[[home]]
+      away_xg_team <- team_stats$team_xg_for[[away]]
+      league_avg <- team_stats$league_avg
+      if (!is.null(home_xg_team) && !is.null(away_xg_team) && !is.na(league_avg) && league_avg > 0) {
+        xg$home <- as.numeric(xg$home) * (as.numeric(home_xg_team) / as.numeric(league_avg))
+        xg$away <- as.numeric(xg$away) * (as.numeric(away_xg_team) / as.numeric(league_avg))
+      }
+    }
+  }
+
   return(xg)
 }
 
-dcxG <- function(home, away, params = NULL, maxgoal = 10) {
+dcxG <- function(home, away, params = NULL, maxgoal = 10, scores = HockeyModel::scores, use_xg = FALSE) {
   pm <- dcProbMatrix(
     home = home,
     away = away,
     params = params,
-    maxgoal = maxgoal
+    maxgoal = maxgoal,
+    scores = scores,
+    use_xg = use_xg
   )
 
   away_xg <- stats::weighted.mean(0:maxgoal, colSums(pm))
@@ -670,11 +732,12 @@ dcProbMatrix <- function(
   maxgoal = 10,
   scores = HockeyModel::scores,
   expected_mean = NULL,
-  season_percent = NULL
+  season_percent = NULL,
+  use_xg = FALSE
 ) {
   params <- parse_dc_params(params = params)
 
-  xg <- dcLambda(home = home, away = away, params = params)
+  xg <- dcLambda(home = home, away = away, params = params, scores = scores, use_xg = use_xg)
   # Expected goals home
   lambda <- as.numeric(xg$home)
 
@@ -785,14 +848,19 @@ dcSample <- function(
   scores = HockeyModel::scores,
   expected_mean = NULL,
   season_percent = NULL,
-  as_result = TRUE
+  as_result = TRUE,
+  use_xg = FALSE
 ) {
   params <- parse_dc_params(params)
   pm <- dcProbMatrix(
     home = home,
     away = away,
     params = params,
-    maxgoal = maxgoal
+    maxgoal = maxgoal,
+    scores = scores,
+    expected_mean = expected_mean,
+    season_percent = season_percent,
+    use_xg = use_xg
   )
 
   # sometimes there's negative probabilities. This handles that with fakign a very low value instead

--- a/R/dixon-coles.R
+++ b/R/dixon-coles.R
@@ -641,6 +641,70 @@ get_team_xg_stats <- function(scores = HockeyModel::scores) {
 }
 
 
+# Fit a global xG scaling ratio by regressing observed per-team-game xG on predicted
+# lambdas from the current model. Returns a multiplicative ratio to convert
+# predicted lambdas to xG-scaled lambdas (defaults to 1 if insufficient data).
+fit_xg_ratio <- function(params = NULL, scores = HockeyModel::scores, min_games = 10, clamp = c(0.1, 10)) {
+  params <- parse_dc_params(params)
+  if (is.null(scores)) return(1)
+  if (!all(c("HomexG", "AwayxG", "HomeTeam", "AwayTeam") %in% names(scores))) return(1)
+  n <- nrow(scores)
+  if (n == 0) return(1)
+
+  pred_h <- numeric(n)
+  pred_a <- numeric(n)
+
+  for (i in seq_len(n)) {
+    ph <- try(
+      stats::predict(params$m, data.frame(Home = 1, Team = scores$HomeTeam[i], Opponent = scores$AwayTeam[i]), type = "response")[1],
+      TRUE
+    )
+    if (!is.numeric(ph) || is.na(ph)) {
+      ph <- tryCatch(
+        DCPredictErrorRecover(team = scores$HomeTeam[i], opponent = scores$AwayTeam[i], homeiceadv = TRUE, m = params$m),
+        error = function(e) NA
+      )
+    }
+
+    pa <- try(
+      stats::predict(params$m, data.frame(Home = 0, Team = scores$AwayTeam[i], Opponent = scores$HomeTeam[i]), type = "response")[1],
+      TRUE
+    )
+    if (!is.numeric(pa) || is.na(pa)) {
+      pa <- tryCatch(
+        DCPredictErrorRecover(team = scores$AwayTeam[i], opponent = scores$HomeTeam[i], homeiceadv = FALSE, m = params$m),
+        error = function(e) NA
+      )
+    }
+
+    pred_h[i] <- as.numeric(ph)
+    pred_a[i] <- as.numeric(pa)
+  }
+
+  obs_h <- as.numeric(scores$HomexG)
+  obs_a <- as.numeric(scores$AwayxG)
+
+  keep_h <- !is.na(pred_h) & !is.na(obs_h) & pred_h > 0 & is.finite(pred_h) & is.finite(obs_h)
+  keep_a <- !is.na(pred_a) & !is.na(obs_a) & pred_a > 0 & is.finite(pred_a) & is.finite(obs_a)
+
+  count <- sum(keep_h) + sum(keep_a)
+  if (count < min_games) return(1)
+
+  pred_all <- c(pred_h[keep_h], pred_a[keep_a])
+  obs_all <- c(obs_h[keep_h], obs_a[keep_a])
+
+  denom <- sum(pred_all^2, na.rm = TRUE)
+  if (denom <= 0) return(1)
+
+  ratio <- sum(obs_all * pred_all, na.rm = TRUE) / denom
+  if (!is.finite(ratio) || ratio <= 0) ratio <- 1
+
+  # Clamp to avoid extreme scaling
+  ratio <- min(max(ratio, clamp[1]), clamp[2])
+  return(as.numeric(ratio))
+}
+
+
 dcLambda <- function(home, away, params = NULL, scores = HockeyModel::scores, use_xg = FALSE) {
   params <- parse_dc_params(params = params)
   xg <- list("home" = NA, "away" = NA)
@@ -680,17 +744,12 @@ dcLambda <- function(home, away, params = NULL, scores = HockeyModel::scores, us
     )
   }
 
-  # Optionally adjust predicted goals using team-level average xG from historical data.
+  # Optionally adjust predicted goals using fitted xG scaling ratio based on historical xG vs predicted lambdas.
   if (isTRUE(use_xg)) {
-    team_stats <- tryCatch(get_team_xg_stats(scores), error = function(e) NULL)
-    if (!is.null(team_stats)) {
-      home_xg_team <- team_stats$team_xg_for[[home]]
-      away_xg_team <- team_stats$team_xg_for[[away]]
-      league_avg <- team_stats$league_avg
-      if (!is.null(home_xg_team) && !is.null(away_xg_team) && !is.na(league_avg) && league_avg > 0) {
-        xg$home <- as.numeric(xg$home) * (as.numeric(home_xg_team) / as.numeric(league_avg))
-        xg$away <- as.numeric(xg$away) * (as.numeric(away_xg_team) / as.numeric(league_avg))
-      }
+    ratio <- tryCatch(fit_xg_ratio(params = params, scores = scores), error = function(e) 1)
+    if (!is.null(ratio) && is.numeric(ratio) && is.finite(ratio) && ratio > 0) {
+      xg$home <- as.numeric(xg$home) * ratio
+      xg$away <- as.numeric(xg$away) * ratio
     }
   }
 

--- a/R/dixon-coles.R
+++ b/R/dixon-coles.R
@@ -547,6 +547,8 @@ getWeibullParams <- function(
 #' @param expected_mean the mean lambda & mu, used only for regression
 #' @param season_percent the percent complete of the season, used for regression
 #' @param draws Whether draws are allowed. Default True
+#' @param use_xg Whether to use xG-adjusted lambdas when producing the probability matrix (logical)
+#' @param xg_weight Optional blending weight (0..1). If provided, blends xG-based and goal-based probabilities: combined = xg_weight * p_xg + (1-xg_weight) * p_goal
 #'
 #' @return a vector of home win, draw, and away win probability, or if draws=False, a vector of home and away win probability
 #' @export
@@ -559,9 +561,68 @@ DCPredict <- function(
   expected_mean = NULL,
   season_percent = NULL,
   draws = TRUE,
-  use_xg = FALSE
+  use_xg = FALSE,
+  xg_weight = NULL
 ) {
   params <- parse_dc_params(params = params)
+
+  # If a blending weight is supplied, compute both goal-based and xG-based probability
+  # distributions and return their convex combination.
+  if (!is.null(xg_weight) && is.numeric(xg_weight)) {
+    w <- as.numeric(xg_weight)
+    if (is.na(w)) w <- 0
+    w <- min(max(w, 0), 1)
+
+    pm_goal <- dcProbMatrix(
+      home = home,
+      away = away,
+      params = params,
+      maxgoal = maxgoal,
+      scores = scores,
+      expected_mean = expected_mean,
+      season_percent = season_percent,
+      use_xg = FALSE
+    )
+
+    pm_xg <- dcProbMatrix(
+      home = home,
+      away = away,
+      params = params,
+      maxgoal = maxgoal,
+      scores = scores,
+      expected_mean = expected_mean,
+      season_percent = season_percent,
+      use_xg = TRUE
+    )
+
+    p_goal <- c(
+      sum(pm_goal[lower.tri(pm_goal)]),
+      sum(diag(pm_goal)),
+      sum(pm_goal[upper.tri(pm_goal)])
+    )
+    p_xg <- c(
+      sum(pm_xg[lower.tri(pm_xg)]),
+      sum(diag(pm_xg)),
+      sum(pm_xg[upper.tri(pm_xg)])
+    )
+
+    p_combined <- w * p_xg + (1 - w) * p_goal
+    odds <- normalizeOdds(p_combined)
+
+    if (!draws) {
+      HomeWinProbability <- p_combined[1] +
+        normalizeOdds(c(p_combined[1], p_combined[3]))[1] *
+        p_combined[2]
+      AwayWinProbability <- p_combined[3] +
+        normalizeOdds(c(p_combined[1], p_combined[3]))[2] *
+        p_combined[2]
+      odds <- normalizeOdds(c(HomeWinProbability, AwayWinProbability))
+    }
+
+    return(odds)
+  }
+
+  # Default (no blending): generate probability matrix using requested lambda source
   probability_matrix <- dcProbMatrix(
     home = home,
     away = away,
@@ -596,6 +657,87 @@ DCPredict <- function(
   return(odds)
 }
 
+
+# Fit an optimal blending weight between xG-based and goal-based predictions.
+# The function minimizes log loss on historical games by finding w in [0,1]
+# that minimizes logLoss( w * HomeWL_xg + (1-w) * HomeWL_goal , actualResult ).
+fit_xg_weight <- function(params = NULL, scores = HockeyModel::scores, min_games = 30) {
+  params <- parse_dc_params(params)
+  if (is.null(scores) || nrow(scores) == 0) return(0)
+  if (!all(c("HomeTeam", "AwayTeam", "Result") %in% names(scores))) return(0)
+
+  n <- nrow(scores)
+  p_goal_mat <- matrix(NA_real_, nrow = n, ncol = 3)
+  p_xg_mat <- matrix(NA_real_, nrow = n, ncol = 3)
+  results <- rep(NA_real_, n)
+
+  for (i in seq_len(n)) {
+    row <- scores[i, ]
+    if (is.na(row$HomeTeam) || is.na(row$AwayTeam) || is.na(row$Result)) next
+
+    pm_goal <- try(
+      dcProbMatrix(
+        home = row$HomeTeam,
+        away = row$AwayTeam,
+        params = params,
+        maxgoal = 10,
+        scores = scores,
+        use_xg = FALSE
+      ),
+      TRUE
+    )
+    pm_xg <- try(
+      dcProbMatrix(
+        home = row$HomeTeam,
+        away = row$AwayTeam,
+        params = params,
+        maxgoal = 10,
+        scores = scores,
+        use_xg = TRUE
+      ),
+      TRUE
+    )
+
+    if (inherits(pm_goal, "try-error") || inherits(pm_xg, "try-error")) next
+
+    p_goal <- c(sum(pm_goal[lower.tri(pm_goal)]), sum(diag(pm_goal)), sum(pm_goal[upper.tri(pm_goal)]))
+    p_xg <- c(sum(pm_xg[lower.tri(pm_xg)]), sum(diag(pm_xg)), sum(pm_xg[upper.tri(pm_xg)]))
+
+    if (!all(is.finite(p_goal)) || !all(is.finite(p_xg))) next
+
+    p_goal_mat[i, ] <- p_goal
+    p_xg_mat[i, ] <- p_xg
+    results[i] <- as.numeric(row$Result)
+  }
+
+  valid <- which(!is.na(results) & rowSums(is.na(p_goal_mat)) == 0 & rowSums(is.na(p_xg_mat)) == 0)
+  if (length(valid) < min_games) return(0)
+
+  p_goal_mat <- p_goal_mat[valid, , drop = FALSE]
+  p_xg_mat <- p_xg_mat[valid, , drop = FALSE]
+  results_vec <- results[valid]
+
+  # Objective: for a given w, compute combined Home.WL and return logLoss
+  objective <- function(w) {
+    p_comb <- w * p_xg_mat + (1 - w) * p_goal_mat
+    homeWL <- numeric(nrow(p_comb))
+    for (j in seq_len(nrow(p_comb))) {
+      ph <- p_comb[j, 1]
+      pd <- p_comb[j, 2]
+      pa <- p_comb[j, 3]
+      denom <- ph + pa
+      if (!is.finite(denom) || denom <= 0) {
+        homeWL[j] <- ph
+      } else {
+        homeWL[j] <- (ph / denom) * pd + ph
+      }
+    }
+    return(logLoss(homeWL, results_vec))
+  }
+
+  res <- stats::optimize(f = objective, interval = c(0, 1))
+  return(as.numeric(res$minimum))
+}
 #' DC Expected Goals
 #'
 #' @description Given a home and away team, provide lambda values

--- a/tests/testthat/test-xg-adapter.R
+++ b/tests/testthat/test-xg-adapter.R
@@ -1,0 +1,29 @@
+testthat::test_that("get_xg reads from HockeyModel.xg.path", {
+  tmp <- tempfile(fileext = ".csv")
+  gid <- "2024010001"
+
+  df <- data.frame(
+    game_id = c(gid, gid),
+    h_a = c("home", "away"),
+    xgf_all = c(1.23, 0.98),
+    gf_all = c(2, 1),
+    cf_all = c(10, 8),
+    xgf_pk = c(0.0, 0.0),
+    gf_pk = c(0, 0),
+    cf_pk = c(0, 0),
+    xgf_pp = c(0.0, 0.0),
+    gf_pp = c(0, 0),
+    cf_pp = c(0, 0),
+    stringsAsFactors = FALSE
+  )
+  utils::write.csv(df, tmp, row.names = FALSE)
+
+  old_opt <- getOption("HockeyModel.xg.path")
+  options(HockeyModel.xg.path = tmp)
+  on.exit(options(HockeyModel.xg.path = old_opt), add = TRUE)
+
+  res <- get_xg(c(gid))
+  testthat::expect_true("HomexG" %in% names(res))
+  testthat::expect_equal(res$HomexG[1], 1.23)
+  testthat::expect_equal(res$AwayxG[1], 0.98)
+})

--- a/tests/testthat/test-xg-scaling.R
+++ b/tests/testthat/test-xg-scaling.R
@@ -1,0 +1,78 @@
+context("xG scaling and integration tests")
+
+testthat::test_that("fit_xg_ratio recovers a known multiplicative factor", {
+  params <- tryCatch(parse_dc_params(NULL), error = function(e) skip("No model available"))
+
+  # Use a subset of historical scores present in package data
+  sc <- scores[1:40, ]
+  sc$Date <- as.Date(sc$Date)
+
+  # Compute predicted lambdas for subset (fallback to recovery if needed)
+  ph <- sapply(seq_len(nrow(sc)), function(i) {
+    p <- try(stats::predict(params$m, data.frame(Home = 1, Team = sc$HomeTeam[i], Opponent = sc$AwayTeam[i]), type = "response")[1], TRUE)
+    if (!is.numeric(p) || is.na(p)) p <- DCPredictErrorRecover(team = sc$HomeTeam[i], opponent = sc$AwayTeam[i], homeiceadv = TRUE, m = params$m)
+    as.numeric(p)
+  })
+  pa <- sapply(seq_len(nrow(sc)), function(i) {
+    p <- try(stats::predict(params$m, data.frame(Home = 0, Team = sc$AwayTeam[i], Opponent = sc$HomeTeam[i]), type = "response")[1], TRUE)
+    if (!is.numeric(p) || is.na(p)) p <- DCPredictErrorRecover(team = sc$AwayTeam[i], opponent = sc$HomeTeam[i], homeiceadv = FALSE, m = params$m)
+    as.numeric(p)
+  })
+
+  keep <- !is.na(ph) & !is.na(pa) & ph > 0 & pa > 0
+  if (sum(keep) < 5) {
+    skip("Not enough valid predictions in sample to test xG fitting")
+  }
+
+  sc <- sc[keep, ]
+  ph <- ph[keep]
+  pa <- pa[keep]
+
+  true_ratio <- 1.7
+  sc$HomexG <- ph * true_ratio
+  sc$AwayxG <- pa * true_ratio
+
+  ratio <- fit_xg_ratio(params = params, scores = sc, min_games = 1)
+  testthat::expect_equal(ratio, true_ratio, tolerance = 1e-6)
+})
+
+
+testthat::test_that("dcLambda applies fitted scaling when use_xg=TRUE", {
+  params <- tryCatch(parse_dc_params(NULL), error = function(e) skip("No model available"))
+
+  sc <- scores[1:40, ]
+  sc$Date <- as.Date(sc$Date)
+
+  ph <- sapply(seq_len(nrow(sc)), function(i) {
+    p <- try(stats::predict(params$m, data.frame(Home = 1, Team = sc$HomeTeam[i], Opponent = sc$AwayTeam[i]), type = "response")[1], TRUE)
+    if (!is.numeric(p) || is.na(p)) p <- DCPredictErrorRecover(team = sc$HomeTeam[i], opponent = sc$AwayTeam[i], homeiceadv = TRUE, m = params$m)
+    as.numeric(p)
+  })
+  pa <- sapply(seq_len(nrow(sc)), function(i) {
+    p <- try(stats::predict(params$m, data.frame(Home = 0, Team = sc$AwayTeam[i], Opponent = sc$HomeTeam[i]), type = "response")[1], TRUE)
+    if (!is.numeric(p) || is.na(p)) p <- DCPredictErrorRecover(team = sc$AwayTeam[i], opponent = sc$HomeTeam[i], homeiceadv = FALSE, m = params$m)
+    as.numeric(p)
+  })
+
+  keep <- !is.na(ph) & !is.na(pa) & ph > 0 & pa > 0
+  if (sum(keep) < 5) {
+    skip("Not enough valid predictions in sample to test xG scaling")
+  }
+
+  sc <- sc[keep, ]
+  ph <- ph[keep]
+  pa <- pa[keep]
+
+  true_ratio <- 2.0
+  sc$HomexG <- ph * true_ratio
+  sc$AwayxG <- pa * true_ratio
+
+  home <- sc$HomeTeam[1]
+  away <- sc$AwayTeam[1]
+
+  ratio <- fit_xg_ratio(params = params, scores = sc, min_games = 1)
+  no_xg <- dcLambda(home, away, params = params, scores = sc, use_xg = FALSE)$home
+  with_xg <- dcLambda(home, away, params = params, scores = sc, use_xg = TRUE)$home
+
+  testthat::expect_equal(with_xg, no_xg * ratio, tolerance = 1e-6)
+})

--- a/tests/testthat/test-xg-weight.R
+++ b/tests/testthat/test-xg-weight.R
@@ -1,0 +1,33 @@
+context("xG weight blending")
+
+# Ensure blending in DCPredict is a convex combination of the two distributions
+test_that("DCPredict blending equals convex combination", {
+  params <- tryCatch(parse_dc_params(NULL), error = function(e) skip("No model available"))
+
+  # pick two common teams present in sample data
+  home <- "Toronto Maple Leafs"
+  away <- "Ottawa Senators"
+
+  p_goal <- DCPredict(home, away, params = params, use_xg = FALSE)
+  p_xg <- DCPredict(home, away, params = params, use_xg = TRUE)
+  p_blend <- DCPredict(home, away, params = params, xg_weight = 0.3)
+
+  # numeric tolerance a bit loose to avoid numerical differences
+  expect_equal(p_blend, 0.3 * p_xg + 0.7 * p_goal, tolerance = 1e-8)
+})
+
+
+test_that("fit_xg_weight returns value in [0,1] or 0 with insufficient data", {
+  params <- tryCatch(parse_dc_params(NULL), error = function(e) skip("No model available"))
+
+  sc <- scores
+  sc$Date <- as.Date(sc$Date)
+
+  w <- fit_xg_weight(params = params, scores = sc, min_games = 5)
+  expect_true(is.numeric(w))
+  expect_true(w >= 0 && w <= 1)
+
+  # insufficient data should return 0
+  w2 <- fit_xg_weight(params = params, scores = sc[1:2, ], min_games = 10)
+  expect_equal(w2, 0)
+})


### PR DESCRIPTION
Adds DCPredict blending between goal-based and xG-based predictions via an xg_weight parameter, and fit_xg_weight() to optimize that weight via minimizing log-loss on historical games. Includes tests verifying blending behavior and weight fitting fallbacks.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>